### PR TITLE
updated to mingw to tdm-gcc

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -4,14 +4,14 @@
             "name": "Win32",
             "includePath": [
                 "${workspaceFolder}/**",
-                "C:/MinGW/include"
+                "C:/TDM-GCC-32/include"
             ],
             "defines": [
                 "_DEBUG",
                 "UNICODE",
                 "_UNICODE"
             ],
-            "compilerPath": "C:\\MinGW\\bin\\g++"
+            "compilerPath": "C:\\TDM-GCC-32\\bin\\g++"
         }
     ],
     "version": 4

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
       {
         "type": "process",
         "label": "C/C++: Build .exe",
-        "command": "C:\\MinGW\\bin\\g++.exe",
+        "command": "C:\\TDM-GCC-32\\bin\\g++.exe",
         "args": ["-g",
                  "${file}",
                  "-o", 
@@ -25,7 +25,7 @@
           "kind": "build",
           "isDefault": true
         },
-        "detail": "compiler: C:\\MinGW\\bin\\g++.exe"
+        "detail": "compiler: C:\\TDM-GCC-32\\bin\\g++.exe"
       }
     ]
   }

--- a/Home/src/Hut.cpp
+++ b/Home/src/Hut.cpp
@@ -9,7 +9,7 @@ int main()
     int stangle = 45, endangle = 50;
     int radius = 50;
     
-    char data[] = "C:\\MinGW\\lib\\libbgi.a"; //static file
+    char data[] = "C:\\TDM-GCC-32\\lib\\libbgi.a"; //static file
 
     initgraph(&gd, &gm, data);
     x = getmaxx(); // to get the co-ordinates i.e. x & y


### PR DESCRIPTION
MinGW complier is somehow showing fatal error while including header file 'graphics.h' even if the file is available in include folder.
<img width="725" alt="mingw-error" src="https://github.com/ullaskunder3/graphics.h-project-template/assets/83506059/15615e03-fdf2-42f0-9e2f-69695be4eec3">

While TDM-GCC-32 works fine.
<img width="737" alt="tdm" src="https://github.com/ullaskunder3/graphics.h-project-template/assets/83506059/cd5d1fab-542c-4764-9863-bf68b9e39078">
